### PR TITLE
feat: implement server ping response to maintain WebSocket connection

### DIFF
--- a/lib/src/client/reverb_client.dart
+++ b/lib/src/client/reverb_client.dart
@@ -739,6 +739,12 @@ class ReverbClient {
     final event = decodedMessage['event'];
     final data = decodedMessage['data'];
 
+    // Respond to server ping to keep the connection alive (Laravel Reverb ping_interval)
+   if (event == 'pusher:ping') {
+      _sendMessage(jsonEncode({'event': 'pusher:pong', 'data': data}));
+      return;
+    }
+
     if (event == 'pusher:connection_established') {
       // Safely handle connection data - data may be null or not a String
       if (data == null || data is! String) {


### PR DESCRIPTION
- Added handling for 'pusher:ping' event to respond with 'pusher:pong'
- This change ensures the WebSocket connection remains alive during idle periods

This enhancement improves the reliability of the ReverbClient by maintaining active connections with the server.