### PR TITLE
feat: add Flutter web support via conditional export WebSocket factory

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -244,26 +244,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -456,10 +456,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -525,5 +525,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/lib/src/client/reverb_client.dart
+++ b/lib/src/client/reverb_client.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 
 import 'package:meta/meta.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:web_socket_channel/io.dart';
 import '../channels/channel.dart';
 import '../channels/private_channel.dart';
 import '../channels/presence_channel.dart';
@@ -13,6 +12,7 @@ import '../auth/authorizer.dart';
 import '../models/connection_state.dart';
 import '../models/exceptions.dart';
 import '../models/cluster_config.dart';
+import 'ws_connect.dart';
 
 /// A client for interacting with a Laravel Reverb WebSocket server.
 ///
@@ -525,23 +525,20 @@ class ReverbClient {
       final uri = _constructWebSocketUri();
 
       // Create WebSocket with API key headers if provided
-      if (apiKey != null) {
-        final headers = <String, dynamic>{
-          'Authorization': 'Bearer $apiKey',
-          ..._resolvedConfig.additionalHeaders,
-        };
-        _channel = channelFactory != null
-            ? channelFactory!(uri)
-            : IOWebSocketChannel.connect(
-                uri,
-                headers: headers,
-                pingInterval: pingInterval,
-              );
-      } else {
-        _channel = channelFactory != null
-            ? channelFactory!(uri)
-            : IOWebSocketChannel.connect(uri, pingInterval: pingInterval);
-      }
+      // Use platform-adaptive factory: native preserves apiKey headers and
+      // pingInterval; web falls back to WebSocketChannel (browser limitation).
+      _channel = channelFactory != null
+          ? channelFactory!(uri)
+          : createWebSocketChannel(
+              uri,
+              headers: apiKey != null
+                  ? {
+                      'Authorization': 'Bearer $apiKey',
+                      ..._resolvedConfig.additionalHeaders,
+                    }
+                  : null,
+              pingInterval: pingInterval,
+            );
 
       _subscription = _channel?.stream.listen(
         _handleMessage,
@@ -674,9 +671,9 @@ class ReverbClient {
 
     _channels[channelName] = channel;
     channel.subscribe().catchError(
-      (e) => onError?.call(ConnectionException(
-        'Failed to subscribe to $channelName: $e',
-      )),
+      (e) => onError?.call(
+        ConnectionException('Failed to subscribe to $channelName: $e'),
+      ),
     );
 
     return channel;
@@ -737,9 +734,9 @@ class ReverbClient {
 
     _channels[channelName] = channel;
     channel.subscribe().catchError(
-      (e) => onError?.call(ConnectionException(
-        'Failed to subscribe to $channelName: $e',
-      )),
+      (e) => onError?.call(
+        ConnectionException('Failed to subscribe to $channelName: $e'),
+      ),
     );
 
     return channel;
@@ -910,9 +907,11 @@ class ReverbClient {
             channel.socketId = socketId!;
           }
           channel.subscribe().catchError(
-            (e) => onError?.call(ConnectionException(
-              'Failed to resubscribe to ${channel.name}: $e',
-            )),
+            (e) => onError?.call(
+              ConnectionException(
+                'Failed to resubscribe to ${channel.name}: $e',
+              ),
+            ),
           );
         }
       } catch (e) {

--- a/lib/src/client/ws_connect.dart
+++ b/lib/src/client/ws_connect.dart
@@ -1,0 +1,8 @@
+/// Platform-adaptive WebSocket factory.
+///
+/// On Flutter web, [dart:io] is unavailable, so [IOWebSocketChannel] cannot
+/// be used — it throws "Unsupported operation: Platform._version" at runtime.
+/// This conditional export resolves to [ws_connect_web.dart] on web and
+/// [ws_connect_io.dart] on all other platforms, preserving full native
+/// behaviour (headers, pingInterval) while adding web support.
+export 'ws_connect_web.dart' if (dart.library.io) 'ws_connect_io.dart';

--- a/lib/src/client/ws_connect_io.dart
+++ b/lib/src/client/ws_connect_io.dart
@@ -1,0 +1,20 @@
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Native (non-web) implementation: uses [IOWebSocketChannel] to preserve
+/// support for connection-level [headers] (e.g. an apiKey Bearer token) and
+/// [pingInterval] for protocol-level WebSocket keepalive frames.
+WebSocketChannel createWebSocketChannel(
+  Uri uri, {
+  Map<String, dynamic>? headers,
+  Duration? pingInterval,
+}) {
+  if (headers != null) {
+    return IOWebSocketChannel.connect(
+      uri,
+      headers: headers,
+      pingInterval: pingInterval,
+    );
+  }
+  return IOWebSocketChannel.connect(uri, pingInterval: pingInterval);
+}

--- a/lib/src/client/ws_connect_web.dart
+++ b/lib/src/client/ws_connect_web.dart
@@ -1,0 +1,15 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Web implementation: uses the platform-agnostic [WebSocketChannel.connect].
+///
+/// The browser's WebSocket API does not support custom headers during the
+/// handshake, so [headers] and [pingInterval] are intentionally ignored.
+/// Channel-level auth (private/presence) is unaffected — it goes through
+/// the [Authorizer] callback, not the connection headers.
+WebSocketChannel createWebSocketChannel(
+  Uri uri, {
+  Map<String, dynamic>? headers,
+  Duration? pingInterval,
+}) {
+  return WebSocketChannel.connect(uri);
+}

--- a/test/reverb_client_api_key_cluster_test.dart
+++ b/test/reverb_client_api_key_cluster_test.dart
@@ -1,13 +1,30 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pusher_reverb_flutter/pusher_reverb_flutter.dart';
+import 'dart:async';
+import 'dart:convert';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'reverb_client_api_key_cluster_test.mocks.dart';
 
+@GenerateNiceMocks([MockSpec<WebSocketChannel>(), MockSpec<WebSocketSink>()])
 void main() {
   group('ReverbClient API Key and Cluster Tests', () {
+    late MockWebSocketChannel mockChannel;
+    late MockWebSocketSink mockSink;
+    late StreamController<dynamic> streamController;
+
     setUp(() {
       ReverbClient.resetInstance();
+      mockChannel = MockWebSocketChannel();
+      mockSink = MockWebSocketSink();
+      streamController = StreamController<dynamic>.broadcast();
+      when(mockChannel.stream).thenAnswer((_) => streamController.stream);
+      when(mockChannel.sink).thenReturn(mockSink);
     });
 
     tearDown(() {
+      streamController.close();
       ReverbClient.resetInstance();
     });
 
@@ -47,6 +64,99 @@ void main() {
           throwsA(isA<ConnectionException>()),
         );
       });
+
+      test('connect() with apiKey uses channelFactory (web-compat)', () async {
+        Uri? capturedUri;
+        final client = ReverbClient.forTesting(
+          host: 'localhost',
+          port: 8080,
+          appKey: 'test-app',
+          apiKey: 'my-api-key',
+          channelFactory: (uri) {
+            capturedUri = uri;
+            return mockChannel;
+          },
+        );
+
+        await client.connect();
+
+        expect(capturedUri, isNotNull);
+        expect(capturedUri.toString(), 'ws://localhost:8080/app/test-app');
+        client.disconnect();
+      });
+
+      test(
+        'connect() with apiKey receives connection_established (web-compat)',
+        () async {
+          String? connectedSocketId;
+          final client = ReverbClient.forTesting(
+            host: 'localhost',
+            port: 8080,
+            appKey: 'test-app',
+            apiKey: 'my-api-key',
+            onConnected: (socketId) => connectedSocketId = socketId,
+            channelFactory: (_) => mockChannel,
+          );
+
+          await client.connect();
+          streamController.add(
+            jsonEncode({
+              'event': 'pusher:connection_established',
+              'data': jsonEncode({
+                'socket_id': 'socket-1',
+                'activity_timeout': 30,
+              }),
+            }),
+          );
+          await Future.delayed(Duration.zero);
+
+          expect(connectedSocketId, 'socket-1');
+          client.disconnect();
+        },
+      );
+
+      test(
+        'connect() with and without apiKey hit the same code path',
+        () async {
+          Uri? uriWithout;
+          Uri? uriWith;
+
+          final withoutKey = ReverbClient.forTesting(
+            host: 'localhost',
+            port: 8080,
+            appKey: 'test-app',
+            channelFactory: (uri) {
+              uriWithout = uri;
+              return mockChannel;
+            },
+          );
+          await withoutKey.connect();
+          withoutKey.disconnect();
+
+          ReverbClient.resetInstance();
+          final sc2 = StreamController<dynamic>.broadcast();
+          final mc2 = MockWebSocketChannel();
+          final ms2 = MockWebSocketSink();
+          when(mc2.stream).thenAnswer((_) => sc2.stream);
+          when(mc2.sink).thenReturn(ms2);
+
+          final withKey = ReverbClient.forTesting(
+            host: 'localhost',
+            port: 8080,
+            appKey: 'test-app',
+            apiKey: 'my-api-key',
+            channelFactory: (uri) {
+              uriWith = uri;
+              return mc2;
+            },
+          );
+          await withKey.connect();
+          withKey.disconnect();
+          sc2.close();
+
+          expect(uriWithout.toString(), uriWith.toString());
+        },
+      );
     });
 
     group('Cluster Support', () {

--- a/test/reverb_client_api_key_cluster_test.mocks.dart
+++ b/test/reverb_client_api_key_cluster_test.mocks.dart
@@ -40,33 +40,35 @@ class _FakeStreamChannel_1<T> extends _i1.SmartFake
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
-  MockWebSocketChannel() {
-    _i1.throwOnMissingStub(this);
-  }
-
   @override
   _i4.Future<void> get ready =>
       (super.noSuchMethod(
             Invocation.getter(#ready),
             returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
           )
           as _i4.Future<void>);
-
-  @override
-  _i4.Stream<dynamic> get stream =>
-      (super.noSuchMethod(
-            Invocation.getter(#stream),
-            returnValue: _i4.Stream<dynamic>.empty(),
-          )
-          as _i4.Stream<dynamic>);
 
   @override
   _i2.WebSocketSink get sink =>
       (super.noSuchMethod(
             Invocation.getter(#sink),
             returnValue: _FakeWebSocketSink_0(this, Invocation.getter(#sink)),
+            returnValueForMissingStub: _FakeWebSocketSink_0(
+              this,
+              Invocation.getter(#sink),
+            ),
           )
           as _i2.WebSocketSink);
+
+  @override
+  _i4.Stream<dynamic> get stream =>
+      (super.noSuchMethod(
+            Invocation.getter(#stream),
+            returnValue: _i4.Stream<dynamic>.empty(),
+            returnValueForMissingStub: _i4.Stream<dynamic>.empty(),
+          )
+          as _i4.Stream<dynamic>);
 
   @override
   void pipe(_i3.StreamChannel<dynamic>? other) => super.noSuchMethod(
@@ -84,6 +86,10 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
               this,
               Invocation.method(#transform, [transformer]),
             ),
+            returnValueForMissingStub: _FakeStreamChannel_1<S>(
+              this,
+              Invocation.method(#transform, [transformer]),
+            ),
           )
           as _i3.StreamChannel<S>);
 
@@ -94,6 +100,10 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
       (super.noSuchMethod(
             Invocation.method(#transformStream, [transformer]),
             returnValue: _FakeStreamChannel_1<dynamic>(
+              this,
+              Invocation.method(#transformStream, [transformer]),
+            ),
+            returnValueForMissingStub: _FakeStreamChannel_1<dynamic>(
               this,
               Invocation.method(#transformStream, [transformer]),
             ),
@@ -110,6 +120,10 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
               this,
               Invocation.method(#transformSink, [transformer]),
             ),
+            returnValueForMissingStub: _FakeStreamChannel_1<dynamic>(
+              this,
+              Invocation.method(#transformSink, [transformer]),
+            ),
           )
           as _i3.StreamChannel<dynamic>);
 
@@ -120,6 +134,10 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
       (super.noSuchMethod(
             Invocation.method(#changeStream, [change]),
             returnValue: _FakeStreamChannel_1<dynamic>(
+              this,
+              Invocation.method(#changeStream, [change]),
+            ),
+            returnValueForMissingStub: _FakeStreamChannel_1<dynamic>(
               this,
               Invocation.method(#changeStream, [change]),
             ),
@@ -136,6 +154,10 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
               this,
               Invocation.method(#changeSink, [change]),
             ),
+            returnValueForMissingStub: _FakeStreamChannel_1<dynamic>(
+              this,
+              Invocation.method(#changeSink, [change]),
+            ),
           )
           as _i3.StreamChannel<dynamic>);
 
@@ -147,6 +169,54 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
               this,
               Invocation.method(#cast, []),
             ),
+            returnValueForMissingStub: _FakeStreamChannel_1<S>(
+              this,
+              Invocation.method(#cast, []),
+            ),
           )
           as _i3.StreamChannel<S>);
+}
+
+/// A class which mocks [WebSocketSink].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockWebSocketSink extends _i1.Mock implements _i2.WebSocketSink {
+  @override
+  _i4.Future<dynamic> get done =>
+      (super.noSuchMethod(
+            Invocation.getter(#done),
+            returnValue: _i4.Future<dynamic>.value(),
+            returnValueForMissingStub: _i4.Future<dynamic>.value(),
+          )
+          as _i4.Future<dynamic>);
+
+  @override
+  _i4.Future<dynamic> close([int? closeCode, String? closeReason]) =>
+      (super.noSuchMethod(
+            Invocation.method(#close, [closeCode, closeReason]),
+            returnValue: _i4.Future<dynamic>.value(),
+            returnValueForMissingStub: _i4.Future<dynamic>.value(),
+          )
+          as _i4.Future<dynamic>);
+
+  @override
+  void add(dynamic data) => super.noSuchMethod(
+    Invocation.method(#add, [data]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void addError(Object? error, [StackTrace? stackTrace]) => super.noSuchMethod(
+    Invocation.method(#addError, [error, stackTrace]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i4.Future<dynamic> addStream(_i4.Stream<dynamic>? stream) =>
+      (super.noSuchMethod(
+            Invocation.method(#addStream, [stream]),
+            returnValue: _i4.Future<dynamic>.value(),
+            returnValueForMissingStub: _i4.Future<dynamic>.value(),
+          )
+          as _i4.Future<dynamic>);
 }

--- a/test/reverb_client_channel_test.mocks.dart
+++ b/test/reverb_client_channel_test.mocks.dart
@@ -50,15 +50,6 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
           as _i4.Future<void>);
 
   @override
-  _i4.Stream<dynamic> get stream =>
-      (super.noSuchMethod(
-            Invocation.getter(#stream),
-            returnValue: _i4.Stream<dynamic>.empty(),
-            returnValueForMissingStub: _i4.Stream<dynamic>.empty(),
-          )
-          as _i4.Stream<dynamic>);
-
-  @override
   _i2.WebSocketSink get sink =>
       (super.noSuchMethod(
             Invocation.getter(#sink),
@@ -69,6 +60,15 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
             ),
           )
           as _i2.WebSocketSink);
+
+  @override
+  _i4.Stream<dynamic> get stream =>
+      (super.noSuchMethod(
+            Invocation.getter(#stream),
+            returnValue: _i4.Stream<dynamic>.empty(),
+            returnValueForMissingStub: _i4.Stream<dynamic>.empty(),
+          )
+          as _i4.Stream<dynamic>);
 
   @override
   void pipe(_i3.StreamChannel<dynamic>? other) => super.noSuchMethod(

--- a/test/reverb_client_test.mocks.dart
+++ b/test/reverb_client_test.mocks.dart
@@ -50,15 +50,6 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
           as _i4.Future<void>);
 
   @override
-  _i4.Stream<dynamic> get stream =>
-      (super.noSuchMethod(
-            Invocation.getter(#stream),
-            returnValue: _i4.Stream<dynamic>.empty(),
-            returnValueForMissingStub: _i4.Stream<dynamic>.empty(),
-          )
-          as _i4.Stream<dynamic>);
-
-  @override
   _i2.WebSocketSink get sink =>
       (super.noSuchMethod(
             Invocation.getter(#sink),
@@ -69,6 +60,15 @@ class MockWebSocketChannel extends _i1.Mock implements _i2.WebSocketChannel {
             ),
           )
           as _i2.WebSocketSink);
+
+  @override
+  _i4.Stream<dynamic> get stream =>
+      (super.noSuchMethod(
+            Invocation.getter(#stream),
+            returnValue: _i4.Stream<dynamic>.empty(),
+            returnValueForMissingStub: _i4.Stream<dynamic>.empty(),
+          )
+          as _i4.Stream<dynamic>);
 
   @override
   void pipe(_i3.StreamChannel<dynamic>? other) => super.noSuchMethod(


### PR DESCRIPTION
**Problem**

This package doesn't work on Flutter web. connect() imports package:web_socket_channel/io.dart and calls IOWebSocketChannel.connect(), which uses dart:io's Platform class. On Flutter web this throws at runtime:

```
Unsupported operation: Platform._version
```

**Approach**

Add a compile-time conditional export shim that resolves to a platform-specific createWebSocketChannel() function:

```
export 'ws_connect_web.dart' if (dart.library.io) 'ws_connect_io.dart';
```

This avoids a runtime kIsWeb check — only one implementation is ever compiled in, so the dart:io code is completely absent from web builds.

- **Native** (ws_connect_io.dart): uses IOWebSocketChannel.connect() — fully preserves apiKey Authorization header and pingInterval behaviour
- **Web** (ws_connect_web.dart): uses WebSocketChannel.connect() — browser WebSocket API doesn't support custom headers, so headers and pingInterval are intentionally ignored

**Changes**

The `if (apiKey != null) { ... } else { ... }` block in `connect()` is simplified into a single call — the branching logic moves into createWebSocketChannel():

```
// Create WebSocket with API key headers if provided
// Use platform-adaptive factory: native preserves apiKey headers and
// pingInterval; web falls back to WebSocketChannel (browser limitation).
_channel = channelFactory != null
    ? channelFactory!(uri)
    : createWebSocketChannel(
        uri,
        headers: apiKey != null
            ? {'Authorization': 'Bearer $apiKey', ..._resolvedConfig.additionalHeaders}
            : null,
        pingInterval: pingInterval,
      );
```

**Tests**

Added 3 tests to reverb_client_api_key_cluster_test.dart:

- connect() with apiKey invokes channelFactory with the correct URI
- connect() with apiKey receives pusher:connection_established correctly
- connect() with and without apiKey construct the same URI

All tests are passing.

Closes #10 